### PR TITLE
Fix ContentBlock data type

### DIFF
--- a/src/modifiers/insertEmptyBlock.js
+++ b/src/modifiers/insertEmptyBlock.js
@@ -1,5 +1,5 @@
 import { genKey, ContentBlock, EditorState } from 'draft-js';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 
 const insertEmptyBlock = (editorState, blockType = 'unstyled', data = {}) => {
   const contentState = editorState.getCurrentContent();
@@ -13,7 +13,7 @@ const insertEmptyBlock = (editorState, blockType = 'unstyled', data = {}) => {
     key: emptyBlockKey,
     text: '',
     type: blockType,
-    data
+    data: Map().merge(data)
   });
   const blockMap = contentState.getBlockMap();
   const blocksBefore = blockMap.toSeq().takeUntil((value) => value === currentBlock);


### PR DESCRIPTION
Please check this PR 🙇 

The following error occurred.

```
Uncaught TypeError: block.getData(...).get is not a function
```

I think that the `data` type of `ContentBlock` needs to be a instance of `Immutable.Map` .

ref: https://github.com/facebook/draft-js/blob/master/src/model/immutable/ContentBlock.js#L38