### PR TITLE
Doesn't convert block type if `code-block`

### DIFF
--- a/src/modifiers/__test__/handleBlockType-test.js
+++ b/src/modifiers/__test__/handleBlockType-test.js
@@ -37,7 +37,40 @@ describe('handleBlockType', () => {
       );
     });
   });
-
+  describe('if current block type is `code-block`', () => {
+    const rawContentState = {
+      entityMap: {},
+      blocks: [{
+        key: 'item1',
+        text: '#code block',
+        type: 'code-block',
+        depth: 0,
+        inlineStyleRanges: [],
+        entityRanges: [],
+        data: {}
+      }]
+    };
+    const contentState = Draft.convertFromRaw(rawContentState);
+    const selection = new SelectionState({
+      anchorKey: 'item1',
+      anchorOffset: 1,
+      focusKey: 'item1',
+      focusOffset: 1,
+      isBackward: false,
+      hasFocus: true
+    });
+    const editorState = EditorState.forceSelection(
+      EditorState.createWithContent(contentState), selection);
+    it('does not convert block type', () => {
+      const newEditorState = handleBlockType(editorState, ' ');
+      expect(newEditorState).to.equal(editorState);
+      expect(
+        Draft.convertToRaw(newEditorState.getCurrentContent())
+      ).to.deep.equal(
+        rawContentState
+      );
+    });
+  });
   const testCases = {
     'converts from unstyled to header-one': {
       before: {

--- a/src/modifiers/handleBlockType.js
+++ b/src/modifiers/handleBlockType.js
@@ -27,6 +27,9 @@ const handleBlockType = (editorState, character) => {
   const position = currentSelection.getAnchorOffset();
   const line = [text.slice(0, position), character, text.slice(position)].join('');
   const blockType = RichUtils.getCurrentBlockType(editorState);
+  if (blockType === 'code-block') {
+    return editorState;
+  }
   for (let i = 1; i <= 6; i += 1) {
     if (line.indexOf(`${sharps(i)} `) === 0) {
       return changeCurrentBlockType(editorState, blockTypes[i], line.replace(/^#+\s/, ''));


### PR DESCRIPTION
Please review this 🙏 

I think should doesn't convert block type if current block type is `'code-block'` .

ref: 

![dec-12-2016 16-05-33](https://cloud.githubusercontent.com/assets/2001452/21090722/f199955c-c084-11e6-8e6d-7c57e21a74de.gif)
