### PR TITLE
Support pasting markdown

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,8 +19,6 @@
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
     "jsx-a11y/no-static-element-interactions": 0,
-    "class-methods-use-this": 0,
-    "no-plusplus":0,
-    "no-underscore-dangle":0
+    "class-methods-use-this": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,8 @@
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
     "jsx-a11y/no-static-element-interactions": 0,
-    "class-methods-use-this": 0
+    "class-methods-use-this": 0,
+    "no-plusplus":0,
+    "no-underscore-dangle":0
   }
 }

--- a/src/__test__/plugin-test.js
+++ b/src/__test__/plugin-test.js
@@ -305,6 +305,51 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
           });
         });
       });
+      describe('handlePastedText', () => {
+        let pastedText;
+        let html;
+        beforeEach(() => {
+          pastedText = `_hello world_
+          Hello`;
+          subject = () => plugin.handlePastedText(pastedText, html, store);
+        });
+        [
+          'addText',
+          'addEmptyBlock',
+          'handleBlockType',
+          'handleImage',
+          'handleLink',
+          'handleInlineStyle'
+        ].forEach((modifier) => {
+          describe(modifier, () => {
+            beforeEach(() => {
+              createMarkdownShortcutsPlugin.__Rewire__(modifier, modifierSpy); // eslint-disable-line no-underscore-dangle
+            });
+            it('returns handled', () => {
+              expect(subject()).to.equal('handled');
+              expect(modifierSpy).to.have.been.called();
+            });
+          });
+        });
+        describe('nothing in clipboard', () => {
+          beforeEach(() => {
+            pastedText = '';
+          });
+          it('returns not-handled', () => {
+            expect(subject()).to.equal('not-handled');
+          });
+        });
+        describe('pasted just text', () => {
+          beforeEach(() => {
+            pastedText = 'hello';
+            createMarkdownShortcutsPlugin.__Rewire__('addText', modifierSpy); // eslint-disable-line no-underscore-dangle
+          });
+          it('returns handled', () => {
+            expect(subject()).to.equal('handled');
+            expect(modifierSpy).to.have.been.calledWith(currentEditorState, 'hello');
+          });
+        });
+      });
     });
   });
 });

--- a/src/__test__/utils-test.js
+++ b/src/__test__/utils-test.js
@@ -24,7 +24,7 @@ describe('utils test', () => {
     let newEditorState = EditorState.createWithContent(Draft.convertFromRaw(newRawContentState));
     const initialBlockSize = newEditorState.getCurrentContent().getBlockMap().size;
     const randomBlockSize = Math.floor((Math.random() * 50) + 1); // random number bettween 1 to 50
-    for (let i = 0; i < randomBlockSize; i++) { // eslint-disable-line
+    for (let i = 0; i < randomBlockSize; i++) { // eslint-disable-line no-plusplus
       newEditorState = addEmptyBlock(newEditorState);
     }
     const finalBlockSize = newEditorState.getCurrentContent().getBlockMap().size;

--- a/src/__test__/utils-test.js
+++ b/src/__test__/utils-test.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import Draft, { EditorState } from 'draft-js';
+import { addText, addEmptyBlock } from '../utils';
+
+describe('utils test', () => {
+  it('is loaded', () => {
+    expect(addText).to.be.a('function');
+    expect(addEmptyBlock).to.be.a('function');
+  });
+
+  const newRawContentState = {
+    entityMap: {},
+    blocks: [{
+      key: 'item1',
+      text: 'altered!!',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {}
+    }]
+  };
+  it('should add empty block', () => {
+    let newEditorState = EditorState.createWithContent(Draft.convertFromRaw(newRawContentState));
+    const initialBlockSize = newEditorState.getCurrentContent().getBlockMap().size;
+    const randomBlockSize = Math.floor((Math.random() * 50) + 1); // random number bettween 1 to 50
+    for (let i = 0; i < randomBlockSize; i++) { // eslint-disable-line
+      newEditorState = addEmptyBlock(newEditorState);
+    }
+    const finalBlockSize = newEditorState.getCurrentContent().getBlockMap().size;
+    expect(finalBlockSize - initialBlockSize).to.equal(randomBlockSize);
+
+    const lastBlock = newEditorState.getCurrentContent().getLastBlock();
+    expect(lastBlock.getType()).to.equal('unstyled');
+    expect(lastBlock.getText()).to.have.lengthOf(0);
+  });
+
+  it('should addText', () => {
+    let newEditorState = EditorState.createWithContent(Draft.convertFromRaw(newRawContentState));
+    const randomText = Date.now().toString(32);
+    newEditorState = addEmptyBlock(newEditorState);
+    newEditorState = addText(newEditorState, randomText);
+    const currentContent = newEditorState.getCurrentContent();
+    expect(currentContent.hasText()).to.equal(true);
+    const lastBlock = currentContent.getLastBlock();
+    expect(lastBlock.getText()).to.equal(randomText);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import { addText, addEmptyBlock } from './utils';
 
 const INLINE_STYLE_CHARACTERS = [' ', '*', '_'];
 
-function _handleCharacter(editorState, character) {
+function checkCharacterForState(editorState, character) {
   if (INLINE_STYLE_CHARACTERS.indexOf(character) === -1) { return editorState; }
   let newEditorState = handleBlockType(editorState, character);
   if (editorState === newEditorState) {
@@ -35,7 +35,7 @@ function _handleCharacter(editorState, character) {
   return newEditorState;
 }
 
-function _handleReturn(editorState, ev) {
+function checkReturnForState(editorState, ev) {
   let newEditorState = editorState;
   const contentState = editorState.getCurrentContent();
   const selection = editorState.getSelection();
@@ -116,7 +116,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
     },
     handleReturn(ev, { setEditorState, getEditorState }) {
       const editorState = getEditorState();
-      const newEditorState = _handleReturn(editorState, ev);
+      const newEditorState = checkReturnForState(editorState, ev);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
         return 'handled';
@@ -128,7 +128,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
         return 'not-handled';
       }
       const editorState = getEditorState();
-      const newEditorState = _handleCharacter(editorState, character);
+      const newEditorState = checkCharacterForState(editorState, character);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
         return 'handled';
@@ -139,15 +139,15 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       const editorState = getEditorState();
       let newEditorState = editorState;
       let buffer = [];
-      for (let i = 0; i < text.length; i++) {
+      for (let i = 0; i < text.length; i++) { // eslint-disable-line
         if (INLINE_STYLE_CHARACTERS.indexOf(text[i]) >= 0) {
           newEditorState = addText(newEditorState, buffer.join('') + text[i]);
-          newEditorState = _handleCharacter(newEditorState, text[i]);
+          newEditorState = checkCharacterForState(newEditorState, text[i]);
           buffer = [];
         } else if (text[i].charCodeAt(0) === 10) {
           newEditorState = addText(newEditorState, buffer.join(''));
           newEditorState = addEmptyBlock(newEditorState);
-          newEditorState = _handleReturn(newEditorState, {});
+          newEditorState = checkReturnForState(newEditorState, {});
           buffer = [];
         } else if (i === text.length - 1) {
           newEditorState = addText(newEditorState, buffer.join('') + text[i]);

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,9 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
           newEditorState = addEmptyBlock(newEditorState);
           newEditorState = _handleReturn(newEditorState, {});
           buffer.length = 0;
+        } else if (i === text.length - 1) {
+          newEditorState = addText(newEditorState, buffer.join('') + text[i]);
+          buffer.length = 0;
         } else {
           buffer.push(text[i]);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -140,20 +140,20 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
     handlePastedText(text, html, { getEditorState, setEditorState }) {
       const editorState = getEditorState();
       let newEditorState = editorState;
-      const buffer = [];
+      let buffer = [];
       for (let i = 0; i < text.length; i++) {
         if (INLINE_STYLE_CHARACTERS.indexOf(text[i]) >= 0) {
           newEditorState = addText(newEditorState, buffer.join('') + text[i]);
           newEditorState = _handleCharacter(newEditorState, text[i]);
-          buffer.length = 0;
+          buffer = [];
         } else if (text[i].charCodeAt(0) === 10) {
           newEditorState = addText(newEditorState, buffer.join(''));
           newEditorState = addEmptyBlock(newEditorState);
           newEditorState = _handleReturn(newEditorState, {});
-          buffer.length = 0;
+          buffer = [];
         } else if (i === text.length - 1) {
           newEditorState = addText(newEditorState, buffer.join('') + text[i]);
-          buffer.length = 0;
+          buffer = [];
         } else {
           buffer.push(text[i]);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle,no-plusplus */
-
 import React from 'react';
 import {
   blockRenderMap as checkboxBlockRenderMap, CheckableListItem, CheckableListItemUtils, CHECKABLE_LIST_ITEM

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ import { addText, addEmptyBlock } from './utils';
 const INLINE_STYLE_CHARACTERS = [' ', '*', '_'];
 
 function checkCharacterForState(editorState, character) {
-  if (INLINE_STYLE_CHARACTERS.indexOf(character) === -1) { return editorState; }
   let newEditorState = handleBlockType(editorState, character);
   if (editorState === newEditorState) {
     newEditorState = handleImage(editorState, character);

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       const editorState = getEditorState();
       let newEditorState = editorState;
       let buffer = [];
-      for (let i = 0; i < text.length; i++) { // eslint-disable-line
+      for (let i = 0; i < text.length; i++) { // eslint-disable-line no-plusplus
         if (INLINE_STYLE_CHARACTERS.indexOf(text[i]) >= 0) {
           newEditorState = addText(newEditorState, buffer.join('') + text[i]);
           newEditorState = checkCharacterForState(newEditorState, text[i]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,32 @@
+import { genKey, ContentBlock, Modifier, EditorState } from 'draft-js';
+import { List } from 'immutable';
+
+function getEmptyContentBlock() {
+  return new ContentBlock({
+    key: genKey(),
+    text: '',
+    characterList: List(),
+  });
+}
+
+export function addText(editorState, bufferText) {
+  const contentState = Modifier.insertText(editorState.getCurrentContent(), editorState.getSelection(), bufferText);
+  return EditorState.push(editorState, contentState, 'insert-characters');
+}
+
+export function addEmptyBlock(editorState) {
+  let contentState = editorState.getCurrentContent();
+  const emptyBlock = getEmptyContentBlock();
+  const blockMap = contentState.getBlockMap();
+  const selectionState = editorState.getSelection();
+  contentState = contentState.merge({
+    blockMap: blockMap.set(emptyBlock.getKey(), emptyBlock),
+    selectionAfter: selectionState.merge({
+      anchorKey: emptyBlock.getKey(),
+      focusKey: emptyBlock.getKey(),
+      anchorOffset: 0,
+      focusOffset: 0,
+    }),
+  });
+  return EditorState.push(editorState, contentState, 'insert-characters');
+}


### PR DESCRIPTION
Added Support for pasting markdown.

How does it work?
> We get the pasted text using draft-js api handlePastedText. Suppose the pasted text is 
```
Hello World
This is _italic_
This end with *space*
* Strike
End
```

> Every letter is iterated and push into buffer array. On encounter of oneOf(`' ', '*', '_'`). It push the text from buffer into editorState then work as handleBeforeInput is called  then use the newEditorState and clear buffer. similarly in case of enter(return, newline) work as handleReturn is called. In case of end buffer is push into the editorState and finally the new editorState is set.