### PR TITLE
Fix handlePasetedText behavior

### DIFF
--- a/src/__test__/plugin-test.js
+++ b/src/__test__/plugin-test.js
@@ -315,7 +315,7 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
         });
         [
           'replaceText',
-          'addEmptyBlock',
+          'insertEmptyBlock',
           'handleBlockType',
           'handleImage',
           'handleLink',
@@ -347,6 +347,15 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
           it('returns handled', () => {
             expect(subject()).to.equal('handled');
             expect(modifierSpy).to.have.been.calledWith(currentEditorState, 'hello');
+          });
+        });
+        describe('passed `html` argument', () => {
+          beforeEach(() => {
+            pastedText = '# hello';
+            html = '<h1>hello</h1>';
+          });
+          it('returns not-handled', () => {
+            expect(subject()).to.equal('not-handled');
           });
         });
       });

--- a/src/__test__/utils-test.js
+++ b/src/__test__/utils-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import Draft, { EditorState, SelectionState } from 'draft-js';
-import { addText, replaceText, addEmptyBlock } from '../utils';
+import insertEmptyBlock from '../modifiers/insertEmptyBlock';
+import { addText, replaceText } from '../utils';
 
 describe('utils test', () => {
   it('is loaded', () => {
     expect(addText).to.be.a('function');
     expect(replaceText).to.be.a('function');
-    expect(addEmptyBlock).to.be.a('function');
   });
 
   const newRawContentState = {
@@ -21,25 +21,11 @@ describe('utils test', () => {
       data: {}
     }]
   };
-  it('should add empty block', () => {
-    let newEditorState = EditorState.createWithContent(Draft.convertFromRaw(newRawContentState));
-    const initialBlockSize = newEditorState.getCurrentContent().getBlockMap().size;
-    const randomBlockSize = Math.floor((Math.random() * 50) + 1); // random number bettween 1 to 50
-    for (let i = 0; i < randomBlockSize; i++) { // eslint-disable-line no-plusplus
-      newEditorState = addEmptyBlock(newEditorState);
-    }
-    const finalBlockSize = newEditorState.getCurrentContent().getBlockMap().size;
-    expect(finalBlockSize - initialBlockSize).to.equal(randomBlockSize);
-
-    const lastBlock = newEditorState.getCurrentContent().getLastBlock();
-    expect(lastBlock.getType()).to.equal('unstyled');
-    expect(lastBlock.getText()).to.have.lengthOf(0);
-  });
 
   it('should addText', () => {
     let newEditorState = EditorState.createWithContent(Draft.convertFromRaw(newRawContentState));
     const randomText = Date.now().toString(32);
-    newEditorState = addEmptyBlock(newEditorState);
+    newEditorState = insertEmptyBlock(newEditorState);
     newEditorState = addText(newEditorState, randomText);
     const currentContent = newEditorState.getCurrentContent();
     expect(currentContent.hasText()).to.equal(true);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import leaveList from './modifiers/leaveList';
 import insertText from './modifiers/insertText';
 import createLinkDecorator from './decorators/link';
 import createImageDecorator from './decorators/image';
-import { replaceText, addEmptyBlock } from './utils';
+import { replaceText } from './utils';
 
 const INLINE_STYLE_CHARACTERS = [' ', '*', '_'];
 
@@ -135,6 +135,9 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       return 'not-handled';
     },
     handlePastedText(text, html, { getEditorState, setEditorState }) {
+      if (html) {
+        return 'not-handled';
+      }
       const editorState = getEditorState();
       let newEditorState = editorState;
       let buffer = [];
@@ -145,7 +148,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
           buffer = [];
         } else if (text[i].charCodeAt(0) === 10) {
           newEditorState = replaceText(newEditorState, buffer.join(''));
-          newEditorState = addEmptyBlock(newEditorState);
+          newEditorState = insertEmptyBlock(newEditorState);
           newEditorState = checkReturnForState(newEditorState, {});
           buffer = [];
         } else if (i === text.length - 1) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,4 @@
-import { genKey, ContentBlock, Modifier, EditorState } from 'draft-js';
-import { List } from 'immutable';
-
-function getEmptyContentBlock() {
-  return new ContentBlock({
-    key: genKey(),
-    text: '',
-    characterList: List(),
-  });
-}
+import { Modifier, EditorState } from 'draft-js';
 
 export function addText(editorState, bufferText) {
   const contentState = Modifier.insertText(editorState.getCurrentContent(), editorState.getSelection(), bufferText);
@@ -16,22 +7,5 @@ export function addText(editorState, bufferText) {
 
 export function replaceText(editorState, bufferText) {
   const contentState = Modifier.replaceText(editorState.getCurrentContent(), editorState.getSelection(), bufferText);
-  return EditorState.push(editorState, contentState, 'insert-characters');
-}
-
-export function addEmptyBlock(editorState) {
-  let contentState = editorState.getCurrentContent();
-  const emptyBlock = getEmptyContentBlock();
-  const blockMap = contentState.getBlockMap();
-  const selectionState = editorState.getSelection();
-  contentState = contentState.merge({
-    blockMap: blockMap.set(emptyBlock.getKey(), emptyBlock),
-    selectionAfter: selectionState.merge({
-      anchorKey: emptyBlock.getKey(),
-      focusKey: emptyBlock.getKey(),
-      anchorOffset: 0,
-      focusOffset: 0,
-    }),
-  });
   return EditorState.push(editorState, contentState, 'insert-characters');
 }


### PR DESCRIPTION
`addEmptyBlock` inserts a block at the end of line.

https://github.com/ngs/draft-js-markdown-shortcuts-plugin/compare/patch-1?expand=1#diff-2b4ca49d4bb0a774c4d4c1672d7aa781L22

Use `insertEmptyBlock` instead.