### PR TITLE
Use the editor state passed directly from draftjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ demo/public
 .deploy
 test-results.xml
 
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "webpack-hot-middleware": "^2.13.2"
   },
   "peerDependencies": {
-    "draft-js-plugins-editor": "2.0.0-rc2",
+    "draft-js-plugins-editor": "~2.0.0-rc2",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "css-loader": "^0.26.0",
     "css-modules-require-hook": "^4.0.5",
     "dirty-chai": "^1.2.2",
-    "draft-js-plugins-editor": "2.0.0-beta10",
+    "draft-js-plugins-editor": "2.0.0-rc2",
     "draft-js-prism": "ngs/draft-js-prism#6edb31c3805dd1de3fb897cc27fced6bac1bafbb",
     "enzyme": "^2.6.0",
     "eslint": "^3.11.1",
@@ -99,7 +99,7 @@
     "webpack-hot-middleware": "^2.13.2"
   },
   "peerDependencies": {
-    "draft-js-plugins-editor": "2.0.0-beta10",
+    "draft-js-plugins-editor": "2.0.0-rc2",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   ],
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "draft-js": "~0.10.0",
+    "draft-js": "~0.10.1",
     "draft-js-checkable-list-item": "^2.0.4",
     "immutable": "~3.7.4"
   }

--- a/src/__test__/plugin-test.js
+++ b/src/__test__/plugin-test.js
@@ -99,7 +99,7 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
       });
       describe('handleReturn', () => {
         beforeEach(() => {
-          subject = () => plugin.handleReturn(event, store);
+          subject = () => plugin.handleReturn(event, store.getEditorState(), store);
         });
         it('does not handle', () => {
           currentRawContentState = {
@@ -298,7 +298,7 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
         let character;
         beforeEach(() => {
           character = ' ';
-          subject = () => plugin.handleBeforeInput(character, store);
+          subject = () => plugin.handleBeforeInput(character, store.getEditorState(), store);
         });
         [
           'handleBlockType',
@@ -337,7 +337,7 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
           pastedText = `_hello world_
           Hello`;
           html = undefined;
-          subject = () => plugin.handlePastedText(pastedText, html, store);
+          subject = () => plugin.handlePastedText(pastedText, html, store.getEditorState(), store);
         });
         [
           'replaceText',

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleReturn(ev, editorState, { setEditorState, getEditorState }) { // eslint-disable-line no-unused-vars
+    handleReturn(ev, editorState, { setEditorState }) {
       const newEditorState = checkReturnForState(editorState, ev);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
@@ -127,7 +127,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleBeforeInput(character, editorState, { getEditorState, setEditorState }) { // eslint-disable-line no-unused-vars
+    handleBeforeInput(character, editorState, { setEditorState }) {
       if (character !== ' ') {
         return 'not-handled';
       }
@@ -138,7 +138,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handlePastedText(text, html, editorState, { getEditorState, setEditorState }) { // eslint-disable-line no-unused-vars
+    handlePastedText(text, html, editorState, { setEditorState }) {
       if (html) {
         return 'not-handled';
       }

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleReturn(ev, editorState, { setEditorState, getEditorState }) {
+    handleReturn(ev, editorState, { setEditorState, getEditorState }) { // eslint-disable-line no-unused-vars
       const newEditorState = checkReturnForState(editorState, ev);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
@@ -127,7 +127,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleBeforeInput(character, editorState, { getEditorState, setEditorState }) {
+    handleBeforeInput(character, editorState, { getEditorState, setEditorState }) { // eslint-disable-line no-unused-vars
       if (character !== ' ') {
         return 'not-handled';
       }
@@ -138,7 +138,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handlePastedText(text, html, editorState, { getEditorState, setEditorState }) {
+    handlePastedText(text, html, editorState, { getEditorState, setEditorState }) { // eslint-disable-line no-unused-vars
       if (html) {
         return 'not-handled';
       }

--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleReturn(ev, { setEditorState, getEditorState }) {
-      const editorState = getEditorState();
+    handleReturn(ev, editorState, { setEditorState, getEditorState }) {
       const newEditorState = checkReturnForState(editorState, ev);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
@@ -128,11 +127,10 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handleBeforeInput(character, { getEditorState, setEditorState }) {
+    handleBeforeInput(character, editorState, { getEditorState, setEditorState }) {
       if (character !== ' ') {
         return 'not-handled';
       }
-      const editorState = getEditorState();
       const newEditorState = checkCharacterForState(editorState, character);
       if (editorState !== newEditorState) {
         setEditorState(newEditorState);
@@ -140,11 +138,10 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       }
       return 'not-handled';
     },
-    handlePastedText(text, html, { getEditorState, setEditorState }) {
+    handlePastedText(text, html, editorState, { getEditorState, setEditorState }) {
       if (html) {
         return 'not-handled';
       }
-      const editorState = getEditorState();
       let newEditorState = editorState;
       let buffer = [];
       for (let i = 0; i < text.length; i++) { // eslint-disable-line no-plusplus


### PR DESCRIPTION
As of Draft 0.10.1 `editorState` is passed in directly into many handler functions. Unfortunately this changed the arity of these functions and made this plugin incompatible with the latest draft-js and draft-js-plugins: https://github.com/draft-js-plugins/draft-js-plugins/blob/master/draft-js-plugins-editor/CHANGELOG.md#added