### PR TITLE
Fix module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "webpack-hot-middleware": "^2.13.2"
   },
   "peerDependencies": {
-    "draft-js-plugins-editor": "2.0.0-beta10",
+    "draft-js-plugins-editor": "~2.0.0-beta.10 || 2.0.0-beta11 || 2.0.0-beta10",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },
@@ -108,8 +108,8 @@
   ],
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "draft-js": "~0.10.0",
-    "draft-js-checkable-list-item": "^2.0.4",
+    "draft-js": "0.10.0",
+    "draft-js-checkable-list-item": "^2.0.5",
     "immutable": "~3.7.4"
   }
 }


### PR DESCRIPTION
- Fix peerDependencies version of `draft-js-plugins-editor`
- Fixed draft-js version to 0.10.0
