### PR TITLE
Fix blockquote exiting behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ function checkReturnForState(editorState, ev) {
     newEditorState = leaveList(editorState);
   }
   if (newEditorState === editorState &&
-    (ev.ctrlKey || ev.shiftKey || ev.metaKey || ev.altKey || /^header-/.test(type))) {
+    (ev.ctrlKey || ev.shiftKey || ev.metaKey || ev.altKey || /^header-/.test(type) || type === 'blockquote')) {
     newEditorState = insertEmptyBlock(editorState);
   }
   if (newEditorState === editorState && type !== 'code-block' && /^```([\w-]+)?$/.test(text)) {


### PR DESCRIPTION
Before this change, exiting a blockquote required users to press
`SHIFT+ENTER`. That was unexpected behaviour, as in pure markdown
blockquotes stop at a new line.

After this change, blockquotes behave like headings: When `ENTER` is
pressed a new empty block is inserted. This is more expected, and to
continue making blockquotes one can continue inserting `>` at the
beginning of lines.