### PR TITLE
Make the max list depth configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
     },
     onTab(ev, { getEditorState, setEditorState }) {
       const editorState = getEditorState();
-      const newEditorState = adjustBlockDepth(editorState, ev);
+      const newEditorState = adjustBlockDepth(editorState, ev, config.maxDepth);
       if (newEditorState !== editorState) {
         setEditorState(newEditorState);
         return 'handled';

--- a/src/modifiers/adjustBlockDepth.js
+++ b/src/modifiers/adjustBlockDepth.js
@@ -1,12 +1,12 @@
 import { CheckableListItemUtils } from 'draft-js-checkable-list-item';
 import { RichUtils } from 'draft-js';
 
-const adjustBlockDepth = (editorState, ev) => {
-  const newEditorState = CheckableListItemUtils.onTab(ev, editorState, 4);
+const adjustBlockDepth = (editorState, ev, maxDepth = 4) => {
+  const newEditorState = CheckableListItemUtils.onTab(ev, editorState, maxDepth);
   if (newEditorState !== editorState) {
     return newEditorState;
   }
-  return RichUtils.onTab(ev, editorState, 4);
+  return RichUtils.onTab(ev, editorState, maxDepth);
 };
 
 export default adjustBlockDepth;


### PR DESCRIPTION
First off, thank you for the awesome plugin! :)

In our app we want to support 7-depth lists and this plugin was forcing the limit to 4. So, we wanted to add a configuration option for setting the max list depth.