### PR TITLE
Do not modify code when pasting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:js": "BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production node_modules/.bin/babel --out-dir='lib' --ignore='**/__test__/*' src",
     "clean": "node_modules/.bin/rimraf lib; node_modules/.bin/rimraf demo/public",
     "deploy:demo": "COMMIT=$(git rev-parse --short HEAD) && BRANCH=gh-pages && GIT_URL=$(git remote get-url origin) && DIR=.deploy; rm -rf $DIR; (git clone $GIT_URL -b $BRANCH $DIR || (git init $DIR && cd $DIR && git remote add origin $GIT_URL && git checkout -b $BRANCH)) && rm -rf ${DIR}/* && cp -R ${DIR}/../demo/public/* $DIR && cd $DIR && git add -A && git commit -m \"Built artifacts of ${COMMIT} [ci skip]\" && git push origin $BRANCH",
+    "prepare": "npm run build",
     "prepublish": "npm run build",
     "start": "npm run start:dev",
     "start:dev": "node_modules/.bin/babel-node ./demo/server.js",

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,11 @@ const createMarkdownShortcutsPlugin = (config = {}) => {
       let newEditorState = editorState;
       let buffer = [];
       for (let i = 0; i < text.length; i++) { // eslint-disable-line no-plusplus
-        if (INLINE_STYLE_CHARACTERS.indexOf(text[i]) >= 0) {
+        const selection = newEditorState.getSelection();
+        const currentBlock = newEditorState.getCurrentContent().getBlockForKey(selection.getStartKey());
+        const currentBlockType = currentBlock ? currentBlock.getType() : null;
+
+        if (currentBlockType !== 'code-block' && INLINE_STYLE_CHARACTERS.indexOf(text[i]) >= 0) {
           newEditorState = replaceText(newEditorState, buffer.join('') + text[i]);
           newEditorState = checkCharacterForState(newEditorState, text[i]);
           buffer = [];


### PR DESCRIPTION
Currently markdown shortcuts plugin messes up pasted code when it's pasted as plain text. If the code  snippet contains underscores it removes them and applies italic inline style for example.

Steps to reproduce:

1. Add a code block in editor.
2. Paste in `hello_world(input_string)` as plain text into it.
3. Underscores are removed and text becomes hello*world(input*string).

This little fix simply disables applying inline styles when we're currently in a code block.