### PR TITLE
Avoid changeCurrentBlockType for # if a blockType is 'code-block'

### DIFF
--- a/src/modifiers/handleBlockType.js
+++ b/src/modifiers/handleBlockType.js
@@ -28,7 +28,7 @@ const handleBlockType = (editorState, character) => {
   const line = [text.slice(0, position), character, text.slice(position)].join('');
   const blockType = RichUtils.getCurrentBlockType(editorState);
   for (let i = 1; i <= 6; i += 1) {
-    if (line.indexOf(`${sharps(i)} `) === 0) {
+    if (line.indexOf(`${sharps(i)} `) === 0 && blockType !== 'code-block') {
       return changeCurrentBlockType(editorState, blockTypes[i], line.replace(/^#+\s/, ''));
     }
   }


### PR DESCRIPTION
* current version changes block type for `#` even if a blockType is `'code-block'`
  * `#` is likely to be used for code comment
* this PR `avoid changeCurrentBlockType for sharp if a blockType is 'code-block'`

## behavior of current version
https://ngs.github.io/draft-js-markdown-shortcuts-plugin/
![Jan-14-2020 15-03-58](https://user-images.githubusercontent.com/12480170/72318279-31d6f780-36df-11ea-8b83-0bd6dd7bbca4.gif)
