### PR TITLE
missing `this` in state initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const plugins = [createMarkdownShortcutsPlugin()];
 export default class DemoEditor extends Component {
   constructor(props) {
     super(props);
-    state = {
+    this.state = {
       editorState: EditorState.createEmpty(),
     };
   }


### PR DESCRIPTION
the example in the readme fatals with `state is not defined` as it should be `this.state` not `state`